### PR TITLE
BrowserRouter를 HashRouter로 변경, 초기화면을 로그인 화면으로 바꿈

### DIFF
--- a/src/main/component/Appbar.js
+++ b/src/main/component/Appbar.js
@@ -17,7 +17,7 @@ const styles = {
 	},
 };
 
-class Menus extends Component {
+class Appbar extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
@@ -37,10 +37,10 @@ class Menus extends Component {
 			    </AppBar>
 			    <Drawer open={this.state.toggle}>
 			      <MenuItem onClick={this.handleDrawerToggle}>
-			        <Link component={RouterLink} to="/login">
-			          메뉴
-			        </Link>
-			      </MenuItem>
+		            <Link component={RouterLink} to="/">
+		              로그인
+		            </Link>
+		          </MenuItem>
 			      <MenuItem onClick={this.handleDrawerToggle}>
 			        <Link component={RouterLink} to="/users">
 			          사용자 관리
@@ -61,4 +61,4 @@ class Menus extends Component {
 	}
 }
 
-export default withStyles(styles)(Menus);
+export default withStyles(styles)(Appbar);

--- a/src/main/js/App.js
+++ b/src/main/js/App.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Helmet } from 'react-helmet';
 
-import { BrowserRouter as Router, Route } from 'react-router-dom';
-import Menus from '../component/Menus';
+import { HashRouter as Router, Route } from 'react-router-dom';
+import Appbar from '../component/Appbar';
 import UserList from './UserList';
 import GroupList from './GroupList';
 import Login from './Login';
@@ -13,16 +13,16 @@ class App extends Component {
 		return (
 			<div>
 			  <Helmet>
-			    <title>VM Admin Web</title>
-			  </Helmet>
+			    <title>VM Admin Project</title>
+		      </Helmet>
 			  <Router>
-			   <Menus>
+			   <Appbar>
 			     <div>
-			       <Route exact path ="/login" component={Login}/>
+			       <Route exact path ="/" component={Login} />
 			       <Route exact path ="/users" component={UserList}/>
 			       <Route exact path ="/groups" component={GroupList}/>
 			     </div>
-			   </Menus>
+			   </Appbar>
 			  </Router>
 			</div>
 		);


### PR DESCRIPTION
기존 BrowserRouter를 사용하면 Router로 url 전환 후 새로고침하면 404 error가 발생하는 것을 확인. 그 문제를 HashRouter로 변경해서 해결함.